### PR TITLE
adding role name manipulation support for pulling roles from LDAP groups

### DIFF
--- a/SpringSecurityLdapGrailsPlugin.groovy
+++ b/SpringSecurityLdapGrailsPlugin.groovy
@@ -156,6 +156,13 @@ class SpringSecurityLdapGrailsPlugin {
 					userDetailsService = ref('userDetailsService')
 				}
 				retrieveDatabaseRoles = conf.ldap.authorities.retrieveDatabaseRoles // false
+				// Use to cleanup LDAP (Active Directory) Group names
+				// Spaces are automatically converted to underscores
+				rolePrefix = conf.ldap.authorities.prefix // 'ROLE_'
+				roleStripPrefix = conf.ldap.authorities.clean.prefix
+				roleStripSuffix = conf.ldap.authorities.clean.suffix
+				roleConvertDashes = conf.ldap.authorities.clean.dashes
+				roleToUpperCase = conf.ldap.authorities.clean.uppercase
 			}
 		}
 		else if (conf.ldap.authorities.retrieveDatabaseRoles) {
@@ -208,6 +215,7 @@ class SpringSecurityLdapGrailsPlugin {
 			}
 
 			ldapRoleMapper(GrailsLdapRoleMapper) {
+				rolePrefix = conf.ldap.authorities.prefix // 'ROLE_'
 				groupRoleAttributeName = conf.ldap.rememberMe.detailsManager.groupRoleAttributeName // 'cn'
 			}
 
@@ -215,6 +223,8 @@ class SpringSecurityLdapGrailsPlugin {
 				conf.ldap.rememberMe.usernameMapper.userDnBase,
 				conf.ldap.rememberMe.usernameMapper.usernameAttribute)
 		}
+
+		println '... finished configuring Spring Security LDAP'
 	}
 
 	private String[] toStringArray(value) {

--- a/grails-app/conf/DefaultLdapSecurityConfig.groovy
+++ b/grails-app/conf/DefaultLdapSecurityConfig.groovy
@@ -59,6 +59,13 @@ security {
 			groupSearchBase = 'ou=groups,dc=example,dc=com'
 			ignorePartialResultException = false
 			defaultRole = null
+			prefix = 'ROLE_'
+			clean {
+				prefix = null
+				suffix = null
+				dashes = false
+				uppercase = false
+			}
 		}
 		useRememberMe = false
 		rememberMe {

--- a/src/docs/guide/3. Configuration.gdoc
+++ b/src/docs/guide/3. Configuration.gdoc
@@ -42,6 +42,11 @@ ldap.authorities. searchSubtree | @true@ | If @true@ a subtree scope search will
 ldap.authorities. groupSearchBase | @'ou=groups,dc=example, dc=com'@ | The base DN from which the search for group membership should be performed
 ldap.authorities. ignorePartialResultException | @false@ | Whether @PartialResultException@s should be ignored in searches, typically used with Active Directory since AD servers often have a problem with referrals.
 ldap.authorities.defaultRole | none | An optional default role to be assigned to all users
+ldap.authorities.prefix | @'ROLE_'@ | The prefix prepended to group names in order to make them Spring Security Roles.  Changing this is NOT recommended as it can have unforseen consequences within the security filters.
+ldap.authorities.clean.prefix | none | An optional string prefix to strip from the beginning of LDAP group names.  For example, @'EnHS-'@ will change @EnHS-Staff-All@ to @ROLE_Staff-All@
+ldap.authorities.clean.suffix | none | An optional string suffix to strip from the end of LDAP group names.  For example, @'Group'@ will change @Faculty Group@ to @ROLE_Faculty@
+ldap.authorities.clean.dashes | @false@ | Set this to true to replace all dashes with underscores in LDAP group names.  For example, @Staff-All@ will become @ROLE_Staff_All@
+ldap.authorities.clean.uppercase | @false@ |  Set this to true to uppercase all LDAP group names.  For example, @My_Ldap_Group@ will become @ROLE_MY_LDAP_GROUP@
 {table}
 
 h4. Persistent Logins

--- a/src/java/org/codehaus/groovy/grails/plugins/springsecurity/ldap/GrailsLdapRoleMapper.java
+++ b/src/java/org/codehaus/groovy/grails/plugins/springsecurity/ldap/GrailsLdapRoleMapper.java
@@ -30,6 +30,7 @@ import org.springframework.security.core.authority.GrantedAuthorityImpl;
 public class GrailsLdapRoleMapper implements AttributesMapper {
 
 	private String _groupRoleAttributeName;
+	private String _rolePrefix = "ROLE_";
 
 	/**
 	 * {@inheritDoc}
@@ -43,7 +44,7 @@ public class GrailsLdapRoleMapper implements AttributesMapper {
       Object group = ne.next();
       String role = group.toString();
 
-      return new GrantedAuthorityImpl("ROLE_" + role.toUpperCase());
+      return new GrantedAuthorityImpl(_rolePrefix + role.toUpperCase());
 	}
 
 	/**
@@ -53,4 +54,13 @@ public class GrailsLdapRoleMapper implements AttributesMapper {
 	public void setGroupRoleAttributeName(final String name) {
 		_groupRoleAttributeName = name;
 	}
+
+	/**
+	 * Dependency injection for <code>rolePrefix</code>.
+	 * @param rolePrefix defaults to 'ROLE_'.  Changing this is not recommended.
+	 */
+	public void setRolePrefix(final String rolePrefix) {
+		_rolePrefix = rolePrefix;
+	}
+
 }

--- a/test/unit/org/codehaus/groovy/grails/plugins/springsecurity/ldap/GrailsLdapAuthoritiesPopulatorTests.groovy
+++ b/test/unit/org/codehaus/groovy/grails/plugins/springsecurity/ldap/GrailsLdapAuthoritiesPopulatorTests.groovy
@@ -1,0 +1,134 @@
+package org.codehaus.groovy.grails.plugins.springsecurity.ldap
+
+import org.springframework.ldap.core.support.LdapContextSource
+import org.springframework.security.core.authority.GrantedAuthorityImpl
+import grails.test.*
+
+class GrailsLdapAuthoritiesPopulatorTests extends GrailsUnitTestCase {
+
+	def contextSource
+	def rolesToTest 
+
+    protected void setUp() {
+        super.setUp()
+
+		contextSource = new LdapContextSource()
+
+		rolesToTest = ['EnHS-GLNE', 
+			'EnHS-NCS-Financial', 
+			'EnHS-WBFCR', 
+			'EnHS-HS-AssetTrackers', 
+			'EnHS-IT', 
+			'EnHS-NCS-All', 
+			'EnHS-NCS-Remove-List-Member', 
+			'EnHS-NCS-List-Viewer', 
+			'EnHS-NCS-Stress', 
+			'EnHS-HS-Lyris', 
+			'EnHS-Staff', 
+			'NCS-Protected-Stress', 
+			'EnHS-NCS-DocGen-Manage', 
+			'EnHS-NunStudy-Investigator', 
+			'EnHS-NCS-Segment', 
+			'EnHS-NCS', 
+			'EnHS-NCS-Protected-Exec-Function', 
+			'EnHS-MES', 
+			'EnHS-NCS-Edit-List-Member', 
+			'EnHS-NCS-Lookup', 
+			'EnHS-NCS-Protected-Ulnar-Length', 
+			'EnHS-NCS-Receipt', 
+			'NCS-HumanResources', 
+			'EnHS-NCS-Add-List-Member', 
+			'EnHS-HS-DBAs', 
+			'EnHS-NunStudy-Administrative', 
+			'EnHS-NCS-Calling', 
+			'EnHS-NCS-Exec-Function', 
+			'EnHS-NunStudy', 
+			'EnHS-NCS-Segment-Lookup', 
+			'EnHS-NCS-Security', 
+			'EnHS-Print-Admins', 
+			'EnHS-NCS-Formative', 
+			'EnHS-MTC-RemoteDesktopUsers', 
+			'NCS-Ulnar-Length', 
+			'EnHS-HS-All', 
+			'EnHS-AVAD', 
+			'EnHS-NCS-DLR', 
+			'EnHS-NCS-Protected', 
+			'EnHS-NCS-Incentives', 
+			'EnHS-NCST', 
+			'EnHS-HS-IT', 
+			'EnHS-NCS-Nutrition', 
+			'EnHS-HPVHSS', 
+			'EnHS-NCS-Assign-List-Auth', 
+			'EnHS-HS-Staff', 
+			'EnHS-NCS-DocGen', 
+			'EnHS-NCS-List-Admin', 
+			'EnHS-NCS-List-Tester', 
+			'EnHS-NCS-Protected-Nutrition', 
+			'EnHS-NCS-NORC-Data', 
+			'EnHS-NCS-Data', 
+			'EnHS-HS-BulkPrinters', 
+			'NCS-IT', 
+			'EnHS-All', 
+			'EnHS-NCS-Reports']
+    }
+
+	/**
+	 * This one test should cover everything added in the cleanRole() function
+	 */
+    void testMyRoles() {
+
+
+		def grailsLdapAuthoritiesPopulator = new GrailsLdapAuthoritiesPopulator(contextSource, '')
+
+		grailsLdapAuthoritiesPopulator.setGroupRoleAttribute('member')
+		grailsLdapAuthoritiesPopulator.setGroupSearchFilter('fake={0}')
+		grailsLdapAuthoritiesPopulator.setSearchSubtree(true)
+		grailsLdapAuthoritiesPopulator.setDefaultRole('ROLE_USER')
+		grailsLdapAuthoritiesPopulator.setIgnorePartialResultException(false)
+		grailsLdapAuthoritiesPopulator.setRetrieveDatabaseRoles(false)
+		grailsLdapAuthoritiesPopulator.setRoleStripPrefix('EnHS-')
+		grailsLdapAuthoritiesPopulator.setRoleConvertDashes(true)
+		grailsLdapAuthoritiesPopulator.setRoleToUpperCase(true)
+
+		rolesToTest.each { roleName ->
+			def testRole = new GrantedAuthorityImpl("ROLE_" + roleName)
+
+			// the settings should run through all the permutations in one swipe
+			def newRole = grailsLdapAuthoritiesPopulator.cleanRole(testRole)
+
+			def cleanRoleName = 'ROLE_' + roleName.toUpperCase().replaceAll('-', '_').replaceFirst('ENHS_', '')
+
+			// make sure our test did what we expected it to
+			assert cleanRoleName == newRole.getAuthority()
+		}
+
+    }
+
+	/**
+	 * This one test should cover everything added in the cleanRole() function
+	 */
+    void testGetGroupMembershipRoles() {
+
+		def testRole = new GrantedAuthorityImpl("ROLE_Test-Pre Sys-AdminTest-Pre-Test-Post-Group Test-Post")
+
+		def grailsLdapAuthoritiesPopulator = new GrailsLdapAuthoritiesPopulator(contextSource, '')
+
+		grailsLdapAuthoritiesPopulator.setGroupRoleAttribute('member')
+		grailsLdapAuthoritiesPopulator.setGroupSearchFilter('fake={0}')
+		grailsLdapAuthoritiesPopulator.setSearchSubtree(true)
+		grailsLdapAuthoritiesPopulator.setDefaultRole('ROLE_USER')
+		grailsLdapAuthoritiesPopulator.setIgnorePartialResultException(false)
+		grailsLdapAuthoritiesPopulator.setRetrieveDatabaseRoles(false)
+		grailsLdapAuthoritiesPopulator.setRoleStripPrefix('Test-Pre')
+		grailsLdapAuthoritiesPopulator.setRoleStripSuffix('Test-Post')
+		grailsLdapAuthoritiesPopulator.setRoleConvertDashes(true)
+		grailsLdapAuthoritiesPopulator.setRoleToUpperCase(true)
+
+		// the settings should run through all the permutations in one swipe
+		def newRole = grailsLdapAuthoritiesPopulator.cleanRole(testRole)
+
+		// make sure our test did what we expected it to
+		assert "ROLE_SYS_ADMINTEST_PRE_TEST_POST_GROUP" == newRole.getAuthority()
+
+    }
+}


### PR DESCRIPTION
Adds additional role name manipulation support for pulling roles from LDAP groups.

Very handy for cleaning up ugly group names pulled in from Active Directory

Resolves JIRA issues:

http://jira.grails.org/browse/GPSPRINGSECURITYLDAP-3
http://jira.grails.org/browse/GPSPRINGSECURITYLDAP-17
