### PR TITLE
Update dependency on spring-ldap, spring-security-core, fix compiler warning

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,1 +1,1 @@
-app.grails.version=2.3.8
+app.grails.version=2.3.11

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -16,7 +16,7 @@ grails.project.dependency.resolution = {
 	}
 
 	dependencies {
-		String springSecurityVersion = '3.2.3.RELEASE'
+		String springSecurityVersion = '3.2.6.RELEASE'
 
 		compile "org.springframework.security:spring-security-ldap:$springSecurityVersion", {
 			excludes 'apacheds-core', 'apacheds-core-entry', 'apacheds-protocol-ldap', 'apacheds-protocol-shared',

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -30,13 +30,13 @@ grails.project.dependency.resolution = {
 	}
 
 	plugins {
-		compile ':spring-security-core:2.0-RC3'
+		compile ':spring-security-core:2.0-RC4'
 
-		compile(":hibernate:3.6.10.14") {
+		compile(":hibernate:3.6.10.17") {
 			export = false
 		}
 
-		build ':release:3.0.1', ':rest-client-builder:2.0.1', {
+		build ':release:3.0.1', ':rest-client-builder:2.0.3', {
 			export = false
 		}
 	}

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -30,7 +30,7 @@ grails.project.dependency.resolution = {
 	}
 
 	plugins {
-		compile ':spring-security-core:2.0-RC4'
+		compile ':spring-security-core:2.0-SNAPSHOT'
 
 		compile(":hibernate:3.6.10.17") {
 			export = false

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -16,7 +16,7 @@ grails.project.dependency.resolution = {
 	}
 
 	dependencies {
-		String springSecurityVersion = '3.2.6.RELEASE'
+		String springSecurityVersion = '3.2.7.RELEASE'
 
 		compile "org.springframework.security:spring-security-ldap:$springSecurityVersion", {
 			excludes 'apacheds-core', 'apacheds-core-entry', 'apacheds-protocol-ldap', 'apacheds-protocol-shared',
@@ -24,7 +24,7 @@ grails.project.dependency.resolution = {
 			         'logback-classic', 'mockito-core', 'shared-ldap', 'slf4j-api', 'spring-beans', 'spring-context',
 			         'spring-core', 'spring-ldap-core', 'spring-security-core', 'spring-test', 'spring-tx'
 		}
-		runtime('org.springframework.ldap:spring-ldap-core:2.0.2.RELEASE') {
+		runtime('org.springframework.ldap:spring-ldap-core:2.0.3.RELEASE') {
 			excludes 'commons-lang', 'commons-logging', 'easymock', 'gsbase', 'junit', 'spring-beans', 'spring-core', 'spring-tx'
 		}
 	}

--- a/src/java/grails/plugin/springsecurity/ldap/core/GrailsSimpleDirContextAuthenticationStrategy.java
+++ b/src/java/grails/plugin/springsecurity/ldap/core/GrailsSimpleDirContextAuthenticationStrategy.java
@@ -34,7 +34,7 @@ public class GrailsSimpleDirContextAuthenticationStrategy extends SimpleDirConte
 	protected String userDn;
 
 	@Override
-	public void setupEnvironment(@SuppressWarnings("rawtypes") Hashtable env, String dn, String password) {
+	public void setupEnvironment(Hashtable<String, Object> env, String dn, String password) {
 		super.setupEnvironment(env, dn, password);
 		// Remove the pooling flag unless we are authenticating as the 'manager' user.
 		if (!userDn.equals(dn) && env.containsKey(AbstractContextSource.SUN_LDAP_POOLING_FLAG)) {


### PR DESCRIPTION
The spring-security-core plugin now uses 3.2.6.RELEASE, spring-security-ldap should too.